### PR TITLE
Use Leaflet/OpenStreetMap instead of Google Maps

### DIFF
--- a/pinaxcon/templates/homepage.html
+++ b/pinaxcon/templates/homepage.html
@@ -228,38 +228,39 @@ de la Computación a la escuela argentina.</p>
 
 {% endblock %}
 
+{% block styles %}
+  {{ block.super }}
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.1/dist/leaflet.css" />
+{% endblock %}
+
 {% block scripts %}
     {{ block.super }}
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCyG0dHUK_9vhz5neVjdUriBQm91eQppdQ&callback=initMaps" async defer></script>
+    <script src="https://unpkg.com/leaflet@1.0.1/dist/leaflet.js" defer></script>
     <script>
     function initMaps() {
       var LatLngPalihue = {lat: -38.695164, lng: -62.253801};
       var LatLngClub = {lat: -38.719668, lng: -62.266995};
 
-      var mapPalihue = new google.maps.Map(document.getElementById('map-palihue'), {
-        center: LatLngPalihue,
-        scrollwheel: false,
-        zoom: 17
-      });
+      function makeTileLayer() {
+        return L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+          attribution: '&copy; <a href="http://openstreetmap.org/copyright">Colaboradores de OpenStreetMap</a>',
+          maxZoom: 19
+        });
+      }
 
-      var mapClub = new google.maps.Map(document.getElementById('map-club'), {
-        center: LatLngClub,
-        scrollwheel: false,
-        zoom: 18
-      });
+      var mapPalihue = L.map('map-palihue').setView(LatLngPalihue, 17);
+      makeTileLayer().addTo(mapPalihue);
 
-      var marker = new google.maps.Marker({
-        map: mapPalihue,
-        position: LatLngPalihue,
-        title: 'UNS Campus Palihue'
-      });
+      var mapClub = L.map('map-club').setView(LatLngClub, 18);
+      makeTileLayer().addTo(mapClub);
 
-      var marker = new google.maps.Marker({
-        map: mapClub,
-        position: LatLngClub,
-        title: 'Club de emprendedores de Bahía Blanca'
-      });
+      var marker = L.marker(LatLngPalihue).addTo(mapPalihue);
+      marker.bindPopup('UNS Campus Palihue');
 
+      var marker = L.marker(LatLngClub).addTo(mapClub);
+      marker.bindPopup('Club de emprendedores de Bahía Blanca');
     }
+
+    $(document).ready(initMaps);
     </script>
 {% endblock %}


### PR DESCRIPTION
Replace proprietary Google Maps with the FOSS Leaflet library showing maps from OpenStreetMap.

![Screenshot](https://cloud.githubusercontent.com/assets/101955/19571971/ab09d520-96d6-11e6-8c1c-df09b739bb69.jpg)

Possible things to improve:
- Leaflet could be added as a dependency to package.json, and merged into the website's CSS and JS, instead of linking it externally; let me know if this is preferred.
- I left the markers in the same location they were before, but since OSM has buildings in the area, the markers can be positioned more accurately. I don't know in what university building we'll be though.
